### PR TITLE
Extract entry painting into separate module, add inode type icons and tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 authors = ["Ben Brunton <ben.brunton@infinityworks.com>"]
 
 [dependencies]
+ansi_term = "0.10.2"

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -1,4 +1,3 @@
-
 use std::fs;
 
 pub trait DirReader {
@@ -29,7 +28,7 @@ impl DirReader for FsReader {
                 DirType::File
             };
 
-            let f = File{
+            let f = File {
                 label, dir_type
             };
 
@@ -41,6 +40,7 @@ impl DirReader for FsReader {
     }
 }
 
+#[derive(Clone)]
 pub enum DirType {
     File,
     Dir
@@ -52,6 +52,21 @@ pub struct File {
 }
 
 impl File {
+    pub fn new(label: String, dir_type: DirType) -> File {
+        File {
+            label,
+            dir_type
+        }
+    }
+
+    pub fn get_dir_type(&self) -> DirType {
+        self.dir_type.clone()
+    }
+
+    pub fn get_label(&self) -> String {
+        self.label.clone()
+    }
+
     pub fn to_str(&self) -> String {
         self.label.clone()
     }

--- a/src/les/mod.rs
+++ b/src/les/mod.rs
@@ -1,6 +1,7 @@
 // les module
 use std::io::Write;
 use fs::DirReader;
+use style::paint;
 
 pub struct Les</*'args,*/ 'w, 'fs, W: Write + 'w, R: DirReader + 'fs> {
 
@@ -23,7 +24,7 @@ impl</*'args,*/ 'w, 'fs, W: Write + 'w, R: DirReader + 'fs> Les</*'args,*/ 'w, '
         let paths = self.dir_reader.read_dir("./");
 
         for path in paths {
-            let _ = writeln!(self.writer, "{}", path.to_str());
+            let _ = writeln!(self.writer, "{}", paint(path));
         }
 
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
-
 use std::io::stdout;
+
+extern crate ansi_term;
 
 mod les;
 mod fs;
+mod style;
 
 fn main() {
 

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -1,0 +1,51 @@
+use ansi_term::Style;
+use fs::File;
+use fs::DirType;
+
+const ICON_DIRECTORY: char = '\u{1F4C2}';
+const ICON_FILE: char = '\u{1F5CB}';
+const ICON_UNKNOWN: char = '*';
+
+pub fn paint(path: File) -> String {
+    let icon = get_icon(path.get_dir_type());
+
+    return format!(
+        "{} {}",
+        Style::new().bold().paint(icon.to_string()),
+        path.to_str()
+    );
+}
+
+fn get_icon(inode_type: DirType) -> char {
+    match inode_type {
+        DirType::Dir  => ICON_DIRECTORY,
+        DirType::File => ICON_FILE,
+        _             => ICON_UNKNOWN,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use style::*;
+    use ansi_term::Style;
+    use fs;
+
+    #[test]
+    fn it_paints_file_icons() {
+        let label = "LICENSE".to_string();
+        let dir_type = fs::DirType::File;
+        let f = File::new(label, dir_type);
+        let actual = paint(f);
+        assert_eq!(actual, "\u{1b}[1m🗋\u{1b}[0m LICENSE");
+    }
+
+    #[test]
+    fn it_paints_directory_icons() {
+        let label = "scripts/".to_string();
+        let dir_type = fs::DirType::Dir;
+        let f = File::new(label, dir_type);
+        let actual = paint(f);
+        assert_eq!(actual, "\u{1b}[1m📂\u{1b}[0m scripts/");
+    }
+}


### PR DESCRIPTION
Also added `ansi_term` crate to handle richer terminal drawing.