### PR TITLE
Add Cargo.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 **/*.rs.bk
+Cargo.lock


### PR DESCRIPTION
Let's ignore this for now as we're adding new crates all the time and having to reset this file continuously. We could add it back to the tree when les is stable (at least from a deps point of view).