### PR TITLE
Add Printer module and table display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,12 +38,22 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "les"
 version = "0.2.1"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "terminal_size 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -74,6 +84,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "strsim"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "terminal_size"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "termion"
@@ -113,12 +133,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -136,16 +166,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4151c5790817c7d21bbdc6c3530811f798172915f93258244948b93ba19604a6"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "db99f3919e20faa51bb2996057f5031d8685019b5a06139b1ce761da671b8526"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum terminal_size 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef4f7fdb2a063032d361d9a72539380900bc3e0cd9ffc9ca8b677f8c855bae0f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7540f4ffc193e0d3c94121edb19b055670d369f77d5804db11ae053a45b6e7e"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ authors = ["Ben Brunton <ben.b.brunton@gmail.com>"]
 [dependencies]
 ansi_term = "0.10.2"
 clap = "2.29.2"
+terminal_size = "0.1.7"
 toml = "0.4"
 glob = "0.2.11"

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -4,6 +4,7 @@ use terminal_size::{Width, terminal_size};
 use style::paint;
 use decorate::Decorate;
 use fs::File;
+use paintitems::PaintItems;
 
 pub trait Print {
     fn print(&self, paths: Vec<File>);
@@ -18,77 +19,94 @@ impl<'a> TerminalPrinter<'a> {
         TerminalPrinter { decorator }
     }
 
-    fn calculate_columns(&self, inodes: &Vec<File>) -> usize {
+    fn calculate_columns(&self, inodes: &PaintItems) -> usize {
         let inodes_count = inodes.len();
         let terminal_size = terminal_size();
         if let Some((Width(w), _)) = terminal_size {
-            let max_term_cols = (w as f32 / self.get_max_filename_size(inodes) as f32).round() as usize; // 32 is the average filename
-            if inodes_count < max_term_cols {
-                return 1;
-            } else {
-                return max_term_cols;
-            }
+            let max_term_cols = (w as f32 / inodes.get_longest_filename_size() as f32).round() as usize;
+            println!("max_term_cols: {}", max_term_cols);
+            max_term_cols
+            //if inodes_count < max_term_cols {
+            //    return 1;
+            //} else {
+            //    return max_term_cols;
+            //}
         } else {
-            return 1;
+            1
         }
-    }
-
-    fn get_max_filename_size(&self, paths: &Vec<File>) -> usize {
-        if paths.len() == 0 {
-            return 32;
-        }
-
-        let mut max_filename_size = 0;
-        for p in paths {
-            if p.get_label().len() > max_filename_size {
-                max_filename_size = p.get_label().len();
-            }
-        }
-
-        return max_filename_size;
     }
 
     // get the list of all inodes and the max columns
-    fn get_rows(&self, paths: &Vec<File>, max_cols: usize) {
+    fn print_rows(&self, items: &PaintItems, max_cols: usize) {
         // divide total inodes by max cols and that's your `rows_per_col`
-        let num_inodes = paths.len();
-        let mut rows_per_col = ((num_inodes / max_cols) as f32).round() as usize;
+        let num_inodes = items.len();
+        let mut rows_per_col = if num_inodes < max_cols {
+            1
+        } else {
+            ((num_inodes / max_cols) as f32).round() as usize
+        };
+        if num_inodes % max_cols != 0 {
+            //rows_per_col = rows_per_col + 1;
+        }
         println!("{}", num_inodes);
         println!("{}", max_cols);
         println!("{}", rows_per_col);
-        if num_inodes % max_cols != 0 {
-            rows_per_col = rows_per_col + 1;
-        }
 
         // iterate through the array of inodes in steps of `rows_per_col`
         // on each iteration print indent() + paint(path). when your current
-        // path index > paths print "\n" and proceed to the next row
-        for row in 0..rows_per_col {
-            let mut current_file_idx = row;
-            let mut pos = 0;
-            loop {
-                let path = paths.get(current_file_idx);
-                match path {
-                    Some(ref p) => {
-                        let paint_rules = self.decorator.get_paint_rules(p);
-                        if !paint_rules.is_hidden {
-                            self.print_inode_str(paint(&paint_rules), pos);
-                        }
+        // path index > items print "\n" and proceed to the next row
+        //let max_name_length = items.get_longest_filename_size();
 
-                        pos = pos + 32; // max_name_length
-                        current_file_idx = current_file_idx + rows_per_col;
-                    },
-                    None => break
-                }
+        if rows_per_col == 1 {
+            let mut indentation = 0;
+            for item in items.iter() {
+                self.print_inode_str(paint(item), indentation);
+                indentation = 3;
             }
+        } else {
+            // TODO -- Put in separate function
+            let max_column_width = self.get_column_width(&items);
+            for row_num in 0..rows_per_col {
+                let mut current_file_idx = row_num;
+                let mut indentation = 0;
+                let mut prev_item_length = 0;
+                loop {
+                    let item = items.get(current_file_idx);
+                    match item {
+                        Some(ref it) => {
+                            self.print_inode_str(paint(it), indentation);
 
-            println!('\n');
+                            prev_item_length = it.label.len();
+                            indentation = self.get_item_indentation(prev_item_length, max_column_width);
+                            //println!("Position: {}", indentation);
+                            current_file_idx = current_file_idx + rows_per_col;
+                            //println!("Current File Index: {}", current_file_idx);
+                        },
+                        None => break
+                    }
+                }
+
+                print!("\n");
+            }
         }
+
+        println!('\n');
     }
 
-    fn print_inode_str(&self, inode: String, position: usize) {
-        let spacing = " ".repeat(position);
-        println!("{}{}", spacing, inode);
+    fn get_item_indentation(&self, prev_item_length: usize, column_width: usize) -> usize {
+        column_width - prev_item_length - 2
+    }
+
+    fn get_column_width(&self, items: &PaintItems) -> usize {
+        // need to retrieve the highest filename size. That +3 spaces will become your column width
+        // then you determine how much to indent based on a subtraction of the previous item from 
+        // the max column width.
+        items.get_longest_filename_size() + 3
+    }
+
+    fn print_inode_str(&self, inode: String, indentation: usize) {
+        let spacing = " ".repeat(indentation);
+        print!("{}{}", spacing, inode);
     }
 
     //fn indent() {
@@ -99,6 +117,12 @@ impl<'a> TerminalPrinter<'a> {
 
 impl<'a> Print for TerminalPrinter<'a> {
     fn print(&self, paths: Vec<File>) {
-        self.get_rows(&paths, self.calculate_columns(&paths));
+        let mut painted_entries = Vec::new();
+        for path in paths {
+            painted_entries.push(self.decorator.get_paint_rules(&path));
+        }
+        let paint_items = PaintItems::new(painted_entries);
+        let mut visible_items = paint_items.get_visible();
+        self.print_rows(&visible_items, self.calculate_columns(&visible_items));
     }
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -17,16 +17,88 @@ impl<'a> TerminalPrinter<'a> {
     pub fn new(decorator: &'a Decorate) -> TerminalPrinter<'a> {
         TerminalPrinter { decorator }
     }
+
+    fn calculate_columns(&self, inodes: &Vec<File>) -> usize {
+        let inodes_count = inodes.len();
+        let terminal_size = terminal_size();
+        if let Some((Width(w), _)) = terminal_size {
+            let max_term_cols = (w as f32 / self.get_max_filename_size(inodes) as f32).round() as usize; // 32 is the average filename
+            if inodes_count < max_term_cols {
+                return 1;
+            } else {
+                return max_term_cols;
+            }
+        } else {
+            return 1;
+        }
+    }
+
+    fn get_max_filename_size(&self, paths: &Vec<File>) -> usize {
+        if paths.len() == 0 {
+            return 32;
+        }
+
+        let mut max_filename_size = 0;
+        for p in paths {
+            if p.get_label().len() > max_filename_size {
+                max_filename_size = p.get_label().len();
+            }
+        }
+
+        return max_filename_size;
+    }
+
+    // get the list of all inodes and the max columns
+    fn get_rows(&self, paths: &Vec<File>, max_cols: usize) {
+        // divide total inodes by max cols and that's your `rows_per_col`
+        let num_inodes = paths.len();
+        let mut rows_per_col = ((num_inodes / max_cols) as f32).round() as usize;
+        println!("{}", num_inodes);
+        println!("{}", max_cols);
+        println!("{}", rows_per_col);
+        if num_inodes % max_cols != 0 {
+            rows_per_col = rows_per_col + 1;
+        }
+
+        // iterate through the array of inodes in steps of `rows_per_col`
+        // on each iteration print indent() + paint(path). when your current
+        // path index > paths print "\n" and proceed to the next row
+        for row in 0..rows_per_col {
+            let mut current_file_idx = row;
+            let mut pos = 0;
+            loop {
+                let path = paths.get(current_file_idx);
+                match path {
+                    Some(ref p) => {
+                        let paint_rules = self.decorator.get_paint_rules(p);
+                        if !paint_rules.is_hidden {
+                            self.print_inode_str(paint(&paint_rules), pos);
+                        }
+
+                        pos = pos + 32; // max_name_length
+                        current_file_idx = current_file_idx + rows_per_col;
+                    },
+                    None => break
+                }
+            }
+
+            println!('\n');
+        }
+    }
+
+    fn print_inode_str(&self, inode: String, position: usize) {
+        let spacing = " ".repeat(position);
+        println!("{}{}", spacing, inode);
+    }
+
+    //fn indent() {
+    //        let _ = writeln(self.writer, "{}", self.painter.paint(path));
+
+    //}
 }
 
 impl<'a> Print for TerminalPrinter<'a> {
     fn print(&self, paths: Vec<File>) {
-        for path in paths {
-
-            let paint_rules = self.decorator.get_paint_rules(&path);
-            if !paint_rules.is_hidden {
-                println!("{}", paint(&paint_rules));
-            }
-        }
+        self.get_rows(&paths, self.calculate_columns(&paths));
     }
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,0 +1,32 @@
+use std::io::{Stdout,stdout};
+use std::cmp::min;
+use terminal_size::{Width, terminal_size};
+use style::paint;
+use decorate::Decorate;
+use fs::File;
+
+pub trait Print {
+    fn print(&self, paths: Vec<File>);
+}
+
+pub struct TerminalPrinter<'a> {
+    decorator: &'a Decorate<'a>
+}
+
+impl<'a> TerminalPrinter<'a> {
+    pub fn new(decorator: &'a Decorate) -> TerminalPrinter<'a> {
+        TerminalPrinter { decorator }
+    }
+}
+
+impl<'a> Print for TerminalPrinter<'a> {
+    fn print(&self, paths: Vec<File>) {
+        for path in paths {
+
+            let paint_rules = self.decorator.get_paint_rules(&path);
+            if !paint_rules.is_hidden {
+                println!("{}", paint(&paint_rules));
+            }
+        }
+    }
+}

--- a/src/les/mod.rs
+++ b/src/les/mod.rs
@@ -2,27 +2,24 @@
 use std::io::Write;
 use fs::DirReader;
 use decorate::Decorate;
-use paintitems::PaintItems;
-use style::paint;
+use io::Print;
 
-pub struct Les<'a, W: Write + 'a, R: DirReader + 'a> {
-    pub writer: &'a mut W,
+pub struct Les<'a, P: Print + 'a, R: DirReader + 'a> {
+    pub printer: &'a P,
     pub dir_reader: &'a R,
-    path: &'a str,
-    decorator: &'a Decorate<'a>
+    path: &'a str
 }
 
 
-impl<'a, W: Write + 'a, R: DirReader + 'a> Les<'a, W, R> {
+impl<'a, P: Print + 'a, R: DirReader + 'a> Les<'a, P, R> {
 
     pub fn new(
         path: &'a str,
-        writer: &'a mut W,
-        dir_reader: &'a R,
-        decorator: &'a Decorate
-    ) -> Les<'a, W, R> {
+        printer: &'a P,
+        dir_reader: &'a R
+    ) -> Les<'a, P, R> {
 
-        Les { writer, dir_reader, path, decorator }
+        Les { printer, dir_reader, path }
     }
 
     pub fn run(&mut self){
@@ -30,17 +27,7 @@ impl<'a, W: Write + 'a, R: DirReader + 'a> Les<'a, W, R> {
 
         match paths_result {
             Ok(paths) => {
-                let mut painted_entries = Vec::new();
-                for path in paths {
-                    painted_entries.push(self.decorator.get_paint_rules(&path));
-                }
-
-                let paint_items = PaintItems::new(painted_entries);
-                let mut visible_items = paint_items.get_visible();
-
-                for item in visible_items.iter() {
-                    println!("{}", paint(&item));
-                }
+                self.printer.print(paths);
             },
             _ => ()
         }
@@ -55,24 +42,24 @@ mod tests {
     use std;
     use fs;
     use decorate;
+    use io;
 
     #[test]
     fn it_doesnt_error() {
 
         let fs_reader = fs::FsReader;
-        let mut writer = Writer;
+        let printer = Printer;
         let decorator = decorate::Decorate::new(None);
 
-        let mut l = Les::new("./", &mut writer, &fs_reader, &decorator);
+        let mut l = Les::new("./", &printer, &fs_reader);
         l.run();
     }
 
 
-    struct Writer;
+    struct Printer;
 
-    impl std::io::Write for Writer {
-        fn write(&mut self, _: &[u8]) -> Result<usize, std::io::Error>{ Ok(0) }
-        fn flush(&mut self) -> Result<(), std::io::Error>{ Ok(()) }
+    impl io::Print for Printer {
+        fn print(&self, _: Vec<fs::File>) { }
     }
 
 

--- a/src/les/mod.rs
+++ b/src/les/mod.rs
@@ -2,12 +2,13 @@
 use std::io::Write;
 use fs::DirReader;
 use decorate::Decorate;
+use paintitems::PaintItems;
 use io::Print;
 
 pub struct Les<'a, P: Print + 'a, R: DirReader + 'a> {
     pub printer: &'a P,
     pub dir_reader: &'a R,
-    path: &'a str
+    path: &'a str,
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 
 extern crate clap; 
 extern crate ansi_term;
+extern crate terminal_size;
 extern crate toml;
 extern crate glob;
 
@@ -10,6 +11,7 @@ use clap::{App, Arg};
 mod les;
 mod fs;
 mod style;
+mod io;
 mod config;
 mod decorate;
 mod paintitems;
@@ -37,9 +39,8 @@ fn main() {
 
     let decorator = decorate::Decorate::new(Some(&configuration));
 
-    let mut std_out_writer = stdout();
     let fs_reader = fs::FsReader;
-    let mut l = les::Les::new(dir, &mut std_out_writer, &fs_reader, &decorator);
+    let printer = io::TerminalPrinter::new(&decorator);
+    let mut l = les::Les::new(dir, &printer, &fs_reader);
     l.run();
 }
-

--- a/src/paintitems/mod.rs
+++ b/src/paintitems/mod.rs
@@ -21,8 +21,12 @@ impl PaintItems {
         self.items.len()
     }
 
-    pub fn get(&self, index: usize) -> &PaintItem {
-        &self.items[index]
+    pub fn get(&self, index: usize) -> Option<&PaintItem> {
+        if index >= self.items.len() || index < 0 {
+            None
+        } else {
+            Some(&self.items[index])
+        }
     }
 
     pub fn get_visible(&self) -> PaintItems {

--- a/src/paintitems/mod.rs
+++ b/src/paintitems/mod.rs
@@ -100,7 +100,14 @@ mod tests {
         });
 
         let items = PaintItems::new(items);
+        match items.get(0) {
+            Some(ref i) => {
+                assert_eq!(i.label, "LICENSE");
+            },
+            None => {
+                panic!("Failed to retrieve item from item list");
+            }
+        };
         assert_eq!(items.get_visible().len(), 1);
-        assert_eq!(items.get(0).label, "LICENSE");
     }
 }


### PR DESCRIPTION
This PR splits up the printing logic even further so that file lists can be output in potentially different formats and to different output streams (stdout or a file) and decouples printing completely from the `les` module.

It also adds support for multi-column displays (equivalent to invoking `ls` if given enough width). However. this formatting mode is to remain turned off (see `io/mod.rs:119`) until program flags are implemented to allow the user to choose between single-column and the new multi-column display.

Unit tests for this will follow soon, just wanted to get it out ASAP to introduce this refactor and minimise conflicts while developing new features.